### PR TITLE
Add google analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.15.2",
     "@mapbox/rehype-prism": "^0.5.0",
     "@mdx-js/react": "^1.6.22",
+    "@types/gtag.js": "^0.0.4",
     "animejs": "^3.2.1",
     "framer-motion": "^3.3.0",
     "gray-matter": "^4.0.2",

--- a/src/components/Analytics/GoogleAnalytics.tsx
+++ b/src/components/Analytics/GoogleAnalytics.tsx
@@ -1,0 +1,38 @@
+import { route } from "next/dist/next-server/server/router";
+import { useRouter } from "next/router";
+import * as React from "react";
+
+const GA_TRACKING_ID = "UA-150757427-1";
+
+export const usePageviewTracking = () => {
+    const router = useRouter();
+    
+    /* Track page_views */
+    React.useEffect(() => {
+        const handleRouteChange = (url: string) => {
+            gtag('config', GA_TRACKING_ID, {
+                page_path: url,
+            });
+        }
+        router.events.on("routeChangeComplete", handleRouteChange);
+
+        return () => {
+            router.events.off("routeChangeComplete", handleRouteChange);
+        }
+    }, [router.events]);
+}
+
+const initialScript = `
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${GA_TRACKING_ID}', {
+    page_path: window.location.pathname,
+});
+`;
+export const GtagGlobalScript: React.FC = () => (
+    <>
+        <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}></script>
+        <script dangerouslySetInnerHTML={{__html: initialScript}}></script>
+    </>
+);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,14 @@
+import { usePageviewTracking } from "components/Analytics/GoogleAnalytics";
 import Layout from "components/Layout/Layout";
 import { AppProps } from "next/dist/next-server/lib/router/router";
+import { NextWebVitalsMetric } from "next/dist/next-server/lib/utils";
 import * as React from "react";
 import "styles/main.scss";
 
 function MyApp({ Component, pageProps }: AppProps) {
+  usePageviewTracking();
   return (
-    <Layout 
+    <Layout
       currentPage={Component["PAGE_TYPE"]}
     >
       <Component {...pageProps} />
@@ -13,6 +16,15 @@ function MyApp({ Component, pageProps }: AppProps) {
   )
 }
 
+export function reportWebVitals({ name, label, value, id }: NextWebVitalsMetric) {
+  window.gtag('event', name, {
+    event_category:
+      label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
+    value: Math.round(name === 'CLS' ? value * 1000 : value), // values must be integers
+    event_label: id, // id unique to current page load
+    non_interaction: true, // avoids affecting bounce rate.
+  })
+}
 
 
 export default MyApp

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,20 @@
+import { GtagGlobalScript } from 'components/Analytics/GoogleAnalytics'
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head>
+            <GtagGlobalScript />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1161,6 +1161,11 @@
   resolved "https://registry.yarnpkg.com/@types/animejs/-/animejs-3.1.2.tgz#93289a902b0b9bfac3020d29413139dcca6acdbc"
   integrity sha512-GyyuoztWbZMErx9brJQChvvfeMd5vplWU/H6BYVl7JUcLoMaDOVxlqF3d4ypB7TzXnbgnMSykGmjAVVRsvhHhQ==
 
+"@types/gtag.js@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.4.tgz#81427d703b5a889b4fd1c37eaae6f2a6db228e5a"
+  integrity sha512-rn4yaEfryXklAtsiai4xHNUgLjGD8AEPQBNSCTa5QrvccFYYBWJQRGwaHiv2U/wdIzcjOuyyBC23YgdQfq5u/Q==
+
 "@types/hast@^2.0.0":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.1.tgz#b16872f2a6144c7025f296fb9636a667ebb79cd9"


### PR DESCRIPTION
Set up gtag.js as seen in the [Nextjs example code](https://github.com/vercel/next.js/tree/canary/examples/with-google-analytics).

Add `pageview` and `Web Vitals` tracking.